### PR TITLE
fix: logic error in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 url=`cat ./.git/config | grep "url = " | sed "s/^[^=]*= //"`
-if [[ $url == "https://github.com/stardust-kyun/calla" ]]; then # make this case insensitive
+if [[ $url == "https://github.com/stardust-kyun/calla" || $$url == "https://github.com/stardust-kyun/calla.git"  ]]; then # make this case insensitive
 	read -p "
 Which distro would you like to build for?
 


### PR DESCRIPTION
If someone where to do:

git clone https://github.com/Stardust-kyun/calla.git then it wouldn't work, but if they did git clone https://github.com/Stardust-kyun/calla it would, this is due to it checking the git config and not accounting for .git extensions